### PR TITLE
Update executive team resolves #19

### DIFF
--- a/src/assets/club-members.json
+++ b/src/assets/club-members.json
@@ -29,7 +29,7 @@
     "name": "Mathew Paul",
     "role": "exec",
     "pic": "",
-    "position": "Social Director",
+    "position": "Events Officer",
     "styles": [
       {
         "name": "Goju Ryu",
@@ -43,7 +43,7 @@
     "name": "Jane Yang",
     "role": "exec",
     "pic": "",
-    "position": "Financial Officer",
+    "position": "Treasurer",
     "styles": [
       {
         "name": "Goju Ryu",
@@ -53,10 +53,10 @@
     "bio": ""
   },
   {
-    "name": "Sarah",
+    "name": "Sarah Tan",
     "role": "exec",
     "pic": "",
-    "position": "Financial Officer",
+    "position": "Treasurer",
     "styles": [
       {
         "name": "Goju Ryu",
@@ -82,7 +82,7 @@
     "name": "Hafriz Abdul Ghaffar",
     "role": "exec",
     "pic": "",
-    "position": "Financial Officer",
+    "position": "Events Officer",
     "styles": [
       {
         "name": "Goju Ryu",

--- a/src/assets/club-members.json
+++ b/src/assets/club-members.json
@@ -1,6 +1,6 @@
 [
   {
-    "name": "Jane Yang",
+    "name": "Wendy Yao",
     "role": "exec",
     "pic": "",
     "position": "President",
@@ -13,14 +13,14 @@
     "bio": ""
   },
   {
-    "name": "Wendy Yao",
+    "name": "Melinda Ha",
     "role": "exec",
     "pic": "",
-    "position": "Vice President",
+    "position": "Secretary",
     "styles": [
       {
         "name": "Goju Ryu",
-        "grade": 5
+        "grade": 9
       }
     ],
     "bio": ""
@@ -40,10 +40,62 @@
   },
 
   {
-    "name": "Rimal Prasad",
+    "name": "Jane Yang",
     "role": "exec",
     "pic": "",
     "position": "Financial Officer",
+    "styles": [
+      {
+        "name": "Goju Ryu",
+        "grade": 5
+      }
+    ],
+    "bio": ""
+  },
+  {
+    "name": "Sarah",
+    "role": "exec",
+    "pic": "",
+    "position": "Financial Officer",
+    "styles": [
+      {
+        "name": "Goju Ryu",
+        "grade": 7
+      }
+    ],
+    "bio": ""
+  },
+  {
+    "name": "Olivia May",
+    "role": "exec",
+    "pic": "",
+    "position": "Health & Safety Officer",
+    "styles": [
+      {
+        "name": "Goju Ryu",
+        "grade": 9
+      }
+    ],
+    "bio": ""
+  },
+  {
+    "name": "Hafriz Abdul Ghaffar",
+    "role": "exec",
+    "pic": "",
+    "position": "Financial Officer",
+    "styles": [
+      {
+        "name": "Goju Ryu",
+        "grade": 6
+      }
+    ],
+    "bio": ""
+  },
+  {
+    "name": "Kieran Dangerfield",
+    "role": "exec",
+    "pic": "",
+    "position": "General Executive",
     "styles": [
       {
         "name": "Goju Ryu",
@@ -53,49 +105,10 @@
     "bio": ""
   },
   {
-    "name": "Jessica Chen",
-    "role": "exec",
-    "pic": "",
-    "position": "Health & Safety Officer",
-    "styles": [
-      {
-        "name": "Goju Ryu",
-        "grade": 7
-      }
-    ],
-    "bio": ""
-  },
-  {
-    "name": "Francois-Rene Du Toit",
-    "role": "exec",
-    "pic": "",
-    "position": "Health & Safety Officer",
-    "styles": [
-      {
-        "name": "Goju Ryu",
-        "grade": -2
-      }
-    ],
-    "bio": ""
-  },
-  {
-    "name": "Thong Nee Ang",
-    "role": "exec",
-    "pic": "",
-    "position": "Financial Officer",
-    "styles": [
-      {
-        "name": "Goju Ryu",
-        "grade": 7
-      }
-    ],
-    "bio": ""
-  },
-  {
     "name": "Jane Waterhouse",
     "role": "exec",
     "pic": "",
-    "position": "Social Director",
+    "position": "General Executive",
     "styles": [
       {
         "name": "Goju Ryu",


### PR DESCRIPTION
This updates the member list on the site to include the 2020 Executive Team, as per the official listing for the club on UoA Engage. Note that this list is not currently displayed on the website.

Resolves #19 