### PR TITLE
Fix contact form input type bug

### DIFF
--- a/src/components/ContactForm.vue
+++ b/src/components/ContactForm.vue
@@ -15,7 +15,7 @@
       <input
         name="name"
         placeholder="Your name"
-        type="name"
+        type="text"
         required="true"
         class="name"
       >


### PR DESCRIPTION
## Summary
- fix incorrect HTML input type for name field in ContactForm

## Testing
- `npm run build`
- `npm run lint` *(fails: SyntaxError in ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_683fa868ffac8325a6bc1d5ead557a26