### PR TITLE
Fix schedule day spelling

### DIFF
--- a/src/features/auckland-north/AucklandNorth.vue
+++ b/src/features/auckland-north/AucklandNorth.vue
@@ -69,10 +69,10 @@ export default {
   data: function () {
     return {
       mapUrl: "https://www.google.com/maps/d/embed?mid=1lSeGuFy53GDmQIbpM2aS5jWlWWawurI",
-      schedule: [
+        schedule: [
         {
           "index": 1,
-          "day": "Thurdays",
+          "day": "Thursdays",
           "startTime": "6pm",
           "finishTime": "7.30pm",
           "location": "Acacia room, Sunnynook Community Centre, Sunnynook",


### PR DESCRIPTION
## Summary
- correct 'Thurdays' typo in Auckland North schedule

## Testing
- `npm test` *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_e_683fa9ade848832584c41e60c4541443