### PR TITLE
Add Open Graph meta tags

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -17,6 +17,10 @@ import QuoteDisplay from "@/components/QuoteDisplay.vue";
 import SitewideBanner from "@/components/SitewideBanner.vue";
 import { RouterView } from "vue-router";
 
+const pageTitle = "UoA Karate Club";
+const pageDescription =
+  "University of Auckland Karate Club. Find info on training times, locations and more.";
+
 export default {
   name: "App",
   components: {
@@ -26,13 +30,14 @@ export default {
     RouterView
   },
   head: {
-    title: "UoA Karate Club",
+    title: pageTitle,
     meta: [
-      {
-        name: "description",
-        content:
-          "University of Auckland Karate Club. Find info on training times, locations and more.",
-      },
+      { name: "description", content: pageDescription },
+      { property: "og:title", content: pageTitle },
+      { property: "og:description", content: pageDescription },
+      { property: "og:type", content: "website" },
+      { property: "og:url", content: "https://uoa-karate.club" },
+      { property: "og:image", content: "/group-photo.jpg" },
     ],
   },
 };

--- a/src/features/auckland-north/AucklandNorth.vue
+++ b/src/features/auckland-north/AucklandNorth.vue
@@ -47,16 +47,21 @@ import HeroImage from "../../components/HeroImage.vue";
 // import ContactForm from "@/components/ContactForm.vue";
 import Utils from "@/libs/utils.js";
 
+const pageTitle = "Auckland North Karate Club";
+const pageDescription =
+  "We're a Goju Ryu Karate dojo based in Sunnynook on the North Shore. We are open to beginners and experienced martial artists alike. Families and children (12+) are also welcome.";
 
 export default {
   name: "auckland-north",
   head: {
-    title: "Auckland North Karate Club",
+    title: pageTitle,
     meta: [
-      {
-        name: "description",
-        content: "We're a Goju Ryu Karate dojo based in Sunnynook on the North Shore. We are open to beginners and experienced martial artists alike. Families and children (12+) are also welcome."
-      }
+      { name: "description", content: pageDescription },
+      { property: "og:title", content: pageTitle },
+      { property: "og:description", content: pageDescription },
+      { property: "og:type", content: "website" },
+      { property: "og:url", content: "https://uoa-karate.club/#/auckland-north" },
+      { property: "og:image", content: "/group-photo.jpg" }
     ]
   },
   components: {

--- a/src/features/grading-info-page/GradingInfo.vue
+++ b/src/features/grading-info-page/GradingInfo.vue
@@ -36,15 +36,20 @@
 </template>
 
 <script>
+const pageTitle = "What do I need to know for grading again??";
+const pageDescription = "Figure out what the heck you need to know to grade.";
+
 export default {
   name: "GradingInfo",
   head: {
-    title: "What do I need to know for grading again??",
+    title: pageTitle,
     meta: [
-      {
-        name: "description",
-        content: "Figure out what the heck you need to know to grade.",
-      },
+      { name: "description", content: pageDescription },
+      { property: "og:title", content: pageTitle },
+      { property: "og:description", content: pageDescription },
+      { property: "og:type", content: "website" },
+      { property: "og:url", content: "https://uoa-karate.club/#/grading-info" },
+      { property: "og:image", content: "/logo-wide.png" },
     ],
   },
 

--- a/src/features/quiz-page/QuizPage.vue
+++ b/src/features/quiz-page/QuizPage.vue
@@ -52,15 +52,20 @@ import questions from "@/assets/mcq.json";
 import QuestionComponent from "@/components/QuestionComponent.vue";
 import Utils from "@/libs/utils.js";
 
+const pageTitle = "Karate Knowledge Tester";
+const pageDescription = "Test your Karate Knowledge.";
+
 export default {
   name: "QuizPage",
   head: {
-    title: "Karate Knowledge Tester",
+    title: pageTitle,
     meta: [
-      {
-        name: "description",
-        content: "Test your Karate Knowledge."
-      }
+      { name: "description", content: pageDescription },
+      { property: "og:title", content: pageTitle },
+      { property: "og:description", content: pageDescription },
+      { property: "og:type", content: "website" },
+      { property: "og:url", content: "https://uoa-karate.club/#/tester" },
+      { property: "og:image", content: "/logo-wide.png" }
     ]
   },
   components: {


### PR DESCRIPTION
## Summary
- add global OG meta tags to App
- include OG tags for the quiz page
- include OG tags for Auckland North dojo page
- include OG tags for grading info page
- share page title and description strings across meta tags

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_683fabc988348325847c5a4c189c79b5